### PR TITLE
Issue 3 image index PR

### DIFF
--- a/app/views/image_posts/index.html.erb
+++ b/app/views/image_posts/index.html.erb
@@ -2,3 +2,13 @@
 <br />
 <%= link_to("Click here to post a new image", new_image_post_path) %>
 <br /> <br/>
+<% if @posts.any? %>
+    <% @posts.order("created_at DESC").each do |post| %>
+        <%= post.title %>
+        <br/>
+        <%= image_tag(post.image,width: 400) if post.image.attached? %>
+        <br/>
+    <% end %>
+<% else%>
+    <h3>No images posted so far!</h3>
+<%end%>

--- a/app/views/image_posts/new.html.erb
+++ b/app/views/image_posts/new.html.erb
@@ -12,12 +12,12 @@
     <%= form.label :title %><br>
     <%= form.text_field :title %>
   </p>
-  
+
   <p>
     <%= form.label :image %><br>
     <%= form.file_field :image %>
   </p>
-  
+
   <p>
     <%= form.submit %>
   </p>

--- a/app/views/image_posts/show.html.erb
+++ b/app/views/image_posts/show.html.erb
@@ -6,3 +6,4 @@
 
 <%= image_tag(@post.image,width: 400) %>
 <br/>
+<%= link_to("View all images", image_posts_path) %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,4 +1,5 @@
 <h1>Welcome to the Image Sharing App</h1>
 
+<%= link_to("View all posts", image_posts_path) %>
 <br />
 <%= link_to("Submit a new image", new_image_post_path) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,5 @@ Rails.application.routes.draw do
 
   resources :image_posts
 
-  root 'image_posts#new'
+  root 'image_posts#index'
 end

--- a/test/controllers/image_post_controller_test.rb
+++ b/test/controllers/image_post_controller_test.rb
@@ -17,4 +17,30 @@ class ImagePostControllerTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
   end
+
+  test 'should show image' do
+    get image_posts_path(@post)
+    assert_response :success
+  end
+
+  test 'index renders all images ordered by creation date' do
+    file = fixture_file_upload(Rails.root.join('public', 'images.jpeg'), 'image/jpeg')
+
+    newest_post = ImagePost.create!(title: 'Newest', created_at: Time.zone.now, image: file)
+    oldest_post = ImagePost.create!(title: 'Oldest', created_at: Time.zone.now - 10.minutes, image: file)
+
+    get image_posts_path
+    assert_response :success
+    assert_select 'img', 2 do |elements|
+      assert_equal url_for(newest_post.image), elements[0].attributes['src'].value
+      assert_equal url_for(oldest_post.image), elements[1].attributes['src'].value
+    end
+  end
+
+  test 'The landing page has a message when there are no images' do
+    get image_posts_path
+    assert_response :success
+
+    assert_select 'h3', 'No images posted so far!'
+  end
 end


### PR DESCRIPTION
Closes #3 Image Index

- New images that are added show up on the homepage.
- These images are persisted if the browser is closed or even if the server is restarted.
- Newest images appear first.
- Images are not displayed wider than 400px (on both the index and show page).